### PR TITLE
Workspace directory

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,9 +2,40 @@
 
 namespace Phobetor\RabbitMqSupervisorBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+
 /**
  * This bundle uses the rabbit mq bundle's configuration
  */
-class Configuration extends \OldSound\RabbitMqBundle\DependencyInjection\Configuration
+class Configuration  implements ConfigurationInterface
 {
+    /**
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder
+     */
+    public function getConfigTreeBuilder()
+    {
+        $tree = new TreeBuilder();
+
+        $rootNode = $tree->root('rabbit_mq_supervisor');
+
+        $this->addSupervisor($rootNode);
+
+        return $tree;
+    }
+
+    /**
+     * Add supervisor conf to rabbit mq bundle's configuration
+     * @param ArrayNodeDefinition $node
+     */
+    protected function addSupervisor(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->scalarNode('directory_workspace')->defaultValue('"%kernel.root_dir%/supervisor/%kernel.environment%')->end()
+            ->end()
+        ;
+    }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,4 +4,16 @@ parameters:
 services:
     phobetor_rabbitmq_supervisor:
         class: %phobetor_rabbitmq_supervisor.rabbitmq_supervisor_service.class%
-        arguments: [@ivan1986_supervisor.supervisor_service, %kernel.root_dir%, %phobetor_rabbitmq_supervisor.consumers%, %phobetor_rabbitmq_supervisor.multiple_consumers%]
+        arguments:
+            - @ivan1986_supervisor.supervisor_service
+            - %kernel.root_dir%
+            - %phobetor_rabbitmq_supervisor.directory_workspace%
+            - %phobetor_rabbitmq_supervisor.consumers%
+            - %phobetor_rabbitmq_supervisor.multiple_consumers%
+
+    ivan1986_supervisor.supervisor_service:
+        class: %ivan1986_supervisor.supervisor_service.class%
+        arguments:
+            - @templating
+            - %phobetor_rabbitmq_supervisor.directory_workspace%/dumpedConfig
+            - %ivan1986_supervisor.supervisor_service.name%

--- a/Resources/views/Supervisor/program.conf.twig
+++ b/Resources/views/Supervisor/program.conf.twig
@@ -1,10 +1,10 @@
 {% extends 'SupervisorBundle::programm.conf.twig' %}
 
-{% block cmd %}php console --env={{ app.environment }}{% if 'prod' == app.environment %} --no-debug{% endif %} {{ command }}{% endblock cmd %}
+{% block cmd %}php {{ kernelRootDir }}/console {{ command }} {% if 'prod' in app.environment %}--no-debug {% endif %}-e {{ app.environment }}{% endblock cmd %}
 
 {% block options %}
 {% for name, value in options %}{{ name }}={{ value }}
 {% endfor %}
-stdout_logfile=logs/{{ app.environment }}.log
-stderr_logfile=logs/{{ app.environment }}.log
+stdout_logfile={{ logsDir }}/stdout.log
+stderr_logfile={{ logsDir }}/stderr.log
 {% endblock options %}


### PR DESCRIPTION
Hi,

Firstly, I added a way to store supervisor config dumped files, supervisor pid files and supervisor logs files in a unique workspace directory.

The config to add in config.yml is very simple :

``` yml
rabbit_mq_supervisor:
    directory_workspace: %kernel.root_dir%/supervisor/%kernel.environment%
```

The tree is the following (for exemple if we follow the config above) :

``` yml
app/
    supervisor/
        dev/
            dumpedConfig/
                supervisor/
                    *.conf
            logs/
            pid/
```

Secondly, I changed the program.conf.twig to handle absolute path for console, log path and prod environment (used 'in' instead of '=' in order to handle specifics environments separated with underscores or some specials caracters).

Thanks a lot for your feedback.
Best regards,
Eric Comellas
