### PR TITLE
Make numprocs configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,7 @@ class Configuration  implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode('worker_count')->defaultValue(1)->end()
                 ->scalarNode('supervisor_instance_identifier')->defaultValue('symfony2')->end()
             ->end();
         $this->addPaths($rootNode);
@@ -51,7 +52,6 @@ class Configuration  implements ConfigurationInterface
                         ->scalarNode('worker_configuration_directory')  ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/worker/')->end()
                         ->scalarNode('worker_output_log_file')          ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stdout.log')->end()
                         ->scalarNode('worker_error_log_file')           ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stderr.log')->end()
-                        ->scalarNode('worker_count')                    ->defaultValue(1)->end()
                     ->end()
                 ->end()
             ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -51,6 +51,7 @@ class Configuration  implements ConfigurationInterface
                         ->scalarNode('worker_configuration_directory')  ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/worker/')->end()
                         ->scalarNode('worker_output_log_file')          ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stdout.log')->end()
                         ->scalarNode('worker_error_log_file')           ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stderr.log')->end()
+                        ->scalarNode('worker_count')                    ->defaultValue(1)->end()
                     ->end()
                 ->end()
             ->end()

--- a/DependencyInjection/RabbitMqSupervisorExtension.php
+++ b/DependencyInjection/RabbitMqSupervisorExtension.php
@@ -24,6 +24,7 @@ class RabbitMqSupervisorExtension extends Extension implements PrependExtensionI
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
+        $container->setParameter('phobetor_rabbitmq_supervisor.worker_count', $config['worker_count']);
         $container->setParameter('phobetor_rabbitmq_supervisor.supervisor_instance_identifier', $config['supervisor_instance_identifier']);
         $container->setParameter('phobetor_rabbitmq_supervisor.paths', $config['paths']);
         $container->setParameter('phobetor_rabbitmq_supervisor.workspace', $config['paths']['workspace_directory']);

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,6 +13,7 @@ services:
             - %phobetor_rabbitmq_supervisor.commands%
             - %phobetor_rabbitmq_supervisor.consumers%
             - %phobetor_rabbitmq_supervisor.multiple_consumers%
+            - %phobetor_rabbitmq_supervisor.worker_count%
 
     phobetor_rabbitmq_supervisor.supervisor_service:
         class: %phobetor_rabbitmq_supervisor.supervisor_service.class%

--- a/Services/RabbitMqSupervisor.php
+++ b/Services/RabbitMqSupervisor.php
@@ -263,7 +263,7 @@ class RabbitMqSupervisor
                     'kernelRootDir' => $this->kernelRootDir,
                     'workerOutputLog' => $this->paths['worker_output_log_file'],
                     'workerErrorLog' => $this->paths['worker_error_log_file'],
-                    'numprocs' => 1,
+                    'numprocs' => $this->paths['worker_count'],
                     'options' => array(
                         'startsecs' => '2',
                         'autorestart' => 'true',

--- a/Services/RabbitMqSupervisor.php
+++ b/Services/RabbitMqSupervisor.php
@@ -45,6 +45,11 @@ class RabbitMqSupervisor
     private $multipleConsumers;
 
     /**
+     * @var int
+     */
+    private $workerCount;
+
+    /**
      * Initialize Handler
      *
      * @param \Phobetor\RabbitMqSupervisorBundle\Services\Supervisor $supervisor
@@ -54,8 +59,9 @@ class RabbitMqSupervisor
      * @param array $commands
      * @param array $consumers
      * @param array $multipleConsumers
+     * @param int $workerCount
      */
-    public function __construct(Supervisor $supervisor, EngineInterface $templating, $kernelRootDir, array $paths, array $commands, $consumers, $multipleConsumers)
+    public function __construct(Supervisor $supervisor, EngineInterface $templating, $kernelRootDir, array $paths, array $commands, $consumers, $multipleConsumers, $workerCount)
     {
         $this->supervisor = $supervisor;
         $this->templating = $templating;
@@ -64,6 +70,7 @@ class RabbitMqSupervisor
         $this->commands = $commands;
         $this->consumers = $consumers;
         $this->multipleConsumers = $multipleConsumers;
+        $this->workerCount = $workerCount;
     }
 
     /**
@@ -263,7 +270,7 @@ class RabbitMqSupervisor
                     'kernelRootDir' => $this->kernelRootDir,
                     'workerOutputLog' => $this->paths['worker_output_log_file'],
                     'workerErrorLog' => $this->paths['worker_error_log_file'],
-                    'numprocs' => $this->paths['worker_count'],
+                    'numprocs' => $this->workerCount,
                     'options' => array(
                         'startsecs' => '2',
                         'autorestart' => 'true',


### PR DESCRIPTION
Instead of hardcoding `numprocs= 1`, we need to make it configurable to make better use of our CPU.