### PR TITLE
Allow for individual worker process count configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * This bundle uses the rabbit mq bundle's configuration
+ * This bundle uses the rabbit mq bundle's configuration.
  */
 class Configuration  implements ConfigurationInterface
 {
@@ -27,12 +27,13 @@ class Configuration  implements ConfigurationInterface
             ->end();
         $this->addPaths($rootNode);
         $this->addCommands($rootNode);
+        $this->addWorkers($rootNode);
 
         return $tree;
     }
 
     /**
-     * Add paths configuration
+     * Add paths configuration.
      *
      * @param ArrayNodeDefinition $node
      */
@@ -44,14 +45,14 @@ class Configuration  implements ConfigurationInterface
                 ->arrayNode('paths')
                 ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('workspace_directory')             ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/')->end()
-                        ->scalarNode('configuration_file')              ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisord.conf')->end()
-                        ->scalarNode('pid_file')                        ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisor.pid')->end()
-                        ->scalarNode('sock_file')                       ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisor.sock')->end()
-                        ->scalarNode('log_file')                        ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisord.log')->end()
-                        ->scalarNode('worker_configuration_directory')  ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/worker/')->end()
-                        ->scalarNode('worker_output_log_file')          ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stdout.log')->end()
-                        ->scalarNode('worker_error_log_file')           ->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stderr.log')->end()
+                        ->scalarNode('workspace_directory')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/')->end()
+                        ->scalarNode('configuration_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisord.conf')->end()
+                        ->scalarNode('pid_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisor.pid')->end()
+                        ->scalarNode('sock_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisor.sock')->end()
+                        ->scalarNode('log_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisord.log')->end()
+                        ->scalarNode('worker_configuration_directory')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/worker/')->end()
+                        ->scalarNode('worker_output_log_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stdout.log')->end()
+                        ->scalarNode('worker_error_log_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stderr.log')->end()
                     ->end()
                 ->end()
             ->end()
@@ -59,7 +60,7 @@ class Configuration  implements ConfigurationInterface
     }
 
     /**
-     * Add commands configuration
+     * Add commands configuration.
      *
      * @param ArrayNodeDefinition $node
      */
@@ -73,6 +74,27 @@ class Configuration  implements ConfigurationInterface
                     ->children()
                         ->scalarNode('rabbitmq_consumer')->defaultValue('rabbitmq:consumer -m %%1$d %%2$s')->end()
                         ->scalarNode('rabbitmq_multiple_consumer')->defaultValue('rabbitmq:multiple-consumer -m %%1$d %%2$s')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Add commands configuration.
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    protected function addWorkers(ArrayNodeDefinition $node)
+    {
+        $node
+            ->fixXmlConfig('worker')
+            ->children()
+                ->arrayNode('workers')
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('worker_count')->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/DependencyInjection/RabbitMqSupervisorExtension.php
+++ b/DependencyInjection/RabbitMqSupervisorExtension.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class RabbitMqSupervisorExtension extends Extension implements PrependExtensionInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -30,6 +30,7 @@ class RabbitMqSupervisorExtension extends Extension implements PrependExtensionI
         $container->setParameter('phobetor_rabbitmq_supervisor.workspace', $config['paths']['workspace_directory']);
         $container->setParameter('phobetor_rabbitmq_supervisor.configuration_file', $config['paths']['configuration_file']);
         $container->setParameter('phobetor_rabbitmq_supervisor.commands', $config['commands']);
+        $container->setParameter('phobetor_rabbitmq_supervisor.workers', $config['workers']);
     }
 
     public function prepend(ContainerBuilder $container)
@@ -46,7 +47,7 @@ class RabbitMqSupervisorExtension extends Extension implements PrependExtensionI
                         } else {
                             $attributeValue = array();
                         }
-                        $container->setParameter('phobetor_rabbitmq_supervisor.' . $attribute, $attributeValue);
+                        $container->setParameter('phobetor_rabbitmq_supervisor.'.$attribute, $attributeValue);
                     }
                     break;
             }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,6 +13,7 @@ services:
             - "%phobetor_rabbitmq_supervisor.consumers%"
             - "%phobetor_rabbitmq_supervisor.multiple_consumers%"
             - "%phobetor_rabbitmq_supervisor.worker_count%"
+            - "%phobetor_rabbitmq_supervisor.workers%"
 
     phobetor_rabbitmq_supervisor.supervisor_service:
         class: "%phobetor_rabbitmq_supervisor.supervisor_service.class%"


### PR DESCRIPTION
This PR allows to configure individual worker process count, also fixing issue #8 by adding a configuration option:

```
rabbit_mq_supervisor:
    workers:
        {{worker name}}:
            worker_count: 2 
```
