### PR TITLE
Implement an ability to configure worker options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ class Configuration  implements ConfigurationInterface
             ->end();
         $this->addPaths($rootNode);
         $this->addCommands($rootNode);
+        $this->addWorkerOptions($rootNode);
 
         return $tree;
     }
@@ -74,6 +75,38 @@ class Configuration  implements ConfigurationInterface
                         ->scalarNode('rabbitmq_consumer')->defaultValue('rabbitmq:consumer -m %%1$d %%2$s')->end()
                         ->scalarNode('rabbitmq_multiple_consumer')->defaultValue('rabbitmq:multiple-consumer -m %%1$d %%2$s')->end()
                         ->integerNode('max_messages')->defaultValue('250')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Add worker options configuration
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    protected function addWorkerOptions(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('worker_options')
+                ->addDefaultsIfNotSet()
+                    ->children()
+                        ->integerNode('startsecs')
+                            ->min(0)
+                            ->defaultValue(2)
+                        ->end()
+                        ->booleanNode('autorestart')->defaultTrue()->end()
+                        ->enumNode('stopsignal')
+                            ->values(array('TERM', 'INT', 'KILL'))
+                            ->defaultValue('INT')
+                        ->end()
+                        ->booleanNode('stopasgroup')->defaultTrue()->end()
+                        ->integerNode('stopwaitsecs')
+                            ->min(0)
+                            ->defaultValue(60)
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/DependencyInjection/RabbitMqSupervisorExtension.php
+++ b/DependencyInjection/RabbitMqSupervisorExtension.php
@@ -30,6 +30,7 @@ class RabbitMqSupervisorExtension extends Extension implements PrependExtensionI
         $container->setParameter('phobetor_rabbitmq_supervisor.workspace', $config['paths']['workspace_directory']);
         $container->setParameter('phobetor_rabbitmq_supervisor.configuration_file', $config['paths']['configuration_file']);
         $container->setParameter('phobetor_rabbitmq_supervisor.commands', $config['commands']);
+        $container->setParameter('phobetor_rabbitmq_supervisor.worker_options', $config['worker_options']);
     }
 
     public function prepend(ContainerBuilder $container)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ rabbit_mq_supervisor:
     commands:
         rabbitmq_consumer:              user-specific-command:consumer -m %%1$d %%2$s
         rabbitmq_multiple_consumer:     user-specific-command:multiple-consumer -m %%1$d %%2$s
+    worker_options:
+        startsecs:    2
+        autorestart:  true
+        stopsignal:   INT
+        stopasgroup:  true
+        stopwaitsecs: 60
 ```
 
 ## Usage

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,6 +13,7 @@ services:
             - "%phobetor_rabbitmq_supervisor.consumers%"
             - "%phobetor_rabbitmq_supervisor.multiple_consumers%"
             - "%phobetor_rabbitmq_supervisor.worker_count%"
+            - "%phobetor_rabbitmq_supervisor.worker_options%"
 
     phobetor_rabbitmq_supervisor.supervisor_service:
         class: "%phobetor_rabbitmq_supervisor.supervisor_service.class%"

--- a/Services/RabbitMqSupervisor.php
+++ b/Services/RabbitMqSupervisor.php
@@ -45,6 +45,11 @@ class RabbitMqSupervisor
     private $workerCount;
 
     /**
+     * @var array
+     */
+    private $workerOptions;
+
+    /**
      * Initialize Handler
      *
      * @param \Phobetor\RabbitMqSupervisorBundle\Services\Supervisor $supervisor
@@ -54,8 +59,9 @@ class RabbitMqSupervisor
      * @param array $consumers
      * @param array $multipleConsumers
      * @param int $workerCount
+     * @param array $workerOptions
      */
-    public function __construct(Supervisor $supervisor, EngineInterface $templating, array $paths, array $commands, $consumers, $multipleConsumers, $workerCount)
+    public function __construct(Supervisor $supervisor, EngineInterface $templating, array $paths, array $commands, $consumers, $multipleConsumers, $workerCount, array $workerOptions = array())
     {
         $this->supervisor = $supervisor;
         $this->templating = $templating;
@@ -64,6 +70,7 @@ class RabbitMqSupervisor
         $this->consumers = $consumers;
         $this->multipleConsumers = $multipleConsumers;
         $this->workerCount = $workerCount;
+        $this->workerOptions = $workerOptions;
     }
 
     /**
@@ -271,13 +278,7 @@ class RabbitMqSupervisor
                     'workerOutputLog' => $this->paths['worker_output_log_file'],
                     'workerErrorLog' => $this->paths['worker_error_log_file'],
                     'numprocs' => $this->workerCount,
-                    'options' => array(
-                        'startsecs' => '2',
-                        'autorestart' => 'true',
-                        'stopsignal' => 'INT',
-                        'stopasgroup' => 'true',
-                        'stopwaitsecs' => '60',
-                    )
+                    'options' => $this->transformBoolsToStrings($this->workerOptions),
                 )
             );
         }
@@ -302,5 +303,26 @@ class RabbitMqSupervisor
     private function createSupervisorConfigurationFilePath()
     {
         return $this->paths['configuration_file'];
+    }
+
+    /**
+     * Transform bool array values to string representation.
+     *
+     * @param array $options
+     *
+     * @return array
+     */
+    private function transformBoolsToStrings(array $options)
+    {
+        $transformedOptions = array();
+        foreach ($options as $key => $value) {
+            if (is_bool($value)) {
+                $value = $value ? 'true' : 'false';
+            }
+
+            $transformedOptions[$key] = $value;
+        }
+
+        return $transformedOptions;
     }
 }


### PR DESCRIPTION
Things like worker `worker_configuration_directory` could also have been moved under worker_options configuration key but I wanted this pull request to be backwards compatible. If requested I could move those options there too.