### PR TITLE
workspace_directory (root directory) configuration also applies for the other path options by default

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,8 +3,8 @@
 namespace Phobetor\RabbitMqSupervisorBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * This bundle uses the rabbit mq bundle's configuration
@@ -46,13 +46,13 @@ class Configuration  implements ConfigurationInterface
                 ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('workspace_directory')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/')->end()
-                        ->scalarNode('configuration_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisord.conf')->end()
-                        ->scalarNode('pid_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisor.pid')->end()
-                        ->scalarNode('sock_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisor.sock')->end()
-                        ->scalarNode('log_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/supervisord.log')->end()
-                        ->scalarNode('worker_configuration_directory')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/worker/')->end()
-                        ->scalarNode('worker_output_log_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stdout.log')->end()
-                        ->scalarNode('worker_error_log_file')->defaultValue('%kernel.root_dir%/supervisor/%kernel.environment%/logs/stderr.log')->end()
+                        ->scalarNode('configuration_file')->defaultValue('%phobetor_rabbitmq_supervisor.workspace%supervisord.conf')->end()
+                        ->scalarNode('pid_file')->defaultValue('%phobetor_rabbitmq_supervisor.workspace%supervisor.pid')->end()
+                        ->scalarNode('sock_file')->defaultValue('%phobetor_rabbitmq_supervisor.workspace%supervisor.sock')->end()
+                        ->scalarNode('log_file')->defaultValue('%phobetor_rabbitmq_supervisor.workspace%supervisord.log')->end()
+                        ->scalarNode('worker_configuration_directory')->defaultValue('%phobetor_rabbitmq_supervisor.workspace%worker/')->end()
+                        ->scalarNode('worker_output_log_file')->defaultValue('%phobetor_rabbitmq_supervisor.workspace%logs/stdout.log')->end()
+                        ->scalarNode('worker_error_log_file')->defaultValue('%phobetor_rabbitmq_supervisor.workspace%logs/stderr.log')->end()
                     ->end()
                 ->end()
             ->end()

--- a/Services/RabbitMqSupervisor.php
+++ b/Services/RabbitMqSupervisor.php
@@ -81,7 +81,7 @@ class RabbitMqSupervisor
     {
         $this->createPathDirectories();
 
-        if (!is_file($this->createSupervisorConfigurationFilePath())) {
+        if (!is_file($this->getSupervisorConfigurationFilePath())) {
             $this->generateSupervisorConfiguration();
         }
 
@@ -247,7 +247,7 @@ class RabbitMqSupervisor
             )
         );
         file_put_contents(
-            $this->createSupervisorConfigurationFilePath(),
+            $this->getSupervisorConfigurationFilePath(),
             $content
         );
     }
@@ -405,7 +405,7 @@ class RabbitMqSupervisor
     /**
      * @return string
      */
-    private function createSupervisorConfigurationFilePath()
+    private function getSupervisorConfigurationFilePath()
     {
         return $this->paths['configuration_file'];
     }


### PR DESCRIPTION
This will eliminate the need to define *all* path configuration options if you want to adjust the default path.

```yaml
rabbit_mq_supervisor:
    paths:
        workspace_directory:            /path/to/workspace
        configuration_file:             /path/to/workspace/supervisord.conf
        pid_file:                       /path/to/workspace/supervisord.pid
        sock_file:                      /path/to/workspace/supervisord.sock
        log_file:                       /path/to/workspace/supervisord.log
        worker_configuration_directory: /path/to/workspace/worker
        worker_output_log_file:         /path/to/workspace/logs/%kernel.environment%.log
        worker_error_log_file:          /path/to/workspace/logs/%kernel.environment%.log
```

can be shortened as
```yaml
rabbit_mq_supervisor:
    paths:
        workspace_directory: /path/to/workspace
```

individual overides are still possible
```yaml
rabbit_mq_supervisor:
    paths:
        workspace_directory: /path/to/workspace
        sock_file: /var/run/supervisord.sock
```

This change should be backwards compatible as previous setup required you to define all path options