### PR TITLE
Unable to detect running processes on Alpine-based system

### DIFF
--- a/Services/RabbitMqSupervisor.php
+++ b/Services/RabbitMqSupervisor.php
@@ -197,13 +197,19 @@ class RabbitMqSupervisor
      */
     private function isProcessRunning($pid) {
         $state = array();
-        exec(sprintf('ps %d', $pid), $state);
+        exec(sprintf('ps %d -o pid', $pid), $state);
+
+        // remove alignment spaces from PIDs
+        $state = array_map('trim', $state);
 
         /*
          * ps will return at least one row, the column labels.
          * If the process is running ps will return a second row with its status.
+         *
+         * Fix: alpine ignores PID argument and always return all processes.
+         * Need to track if PID is not in result
          */
-        return 1 < count($state);
+        return 1 < count($state) && in_array($pid, $state);
     }
 
     /**


### PR DESCRIPTION
The problem is that in alpine `ps` command ignores PID argument. So, when you run `ps 1` you always will receive ALL processes. I added `-o pid` to command to remove useless data and to leave only PIDs and added one more condition to detect if process is running, so finally the process is running if:
- the result of exec has more then 1 line
- PID exists in result of `ps` command

Similar problem: https://github.com/chef/inspec/issues/2034