### PR TITLE
Throw exception if unknown command in used in control console command

### DIFF
--- a/Command/ControlCommand.php
+++ b/Command/ControlCommand.php
@@ -36,6 +36,10 @@ class ControlCommand extends ContainerAwareCommand
             case 'hup':
                 $handler->hup();
                 break;
+            default:
+                throw new \InvalidArgumentException(sprintf(
+                    'Unknown command. Expected (start|stop|restart|hup), given "%s"', $input->getArgument('cmd')
+                ));
         }
     }
 }


### PR DESCRIPTION
For now, when executing command:
```
bin/console rabbitmq-supervisor:control foo
```
it will silently do nothing and user will not know that command is wrong. I added throwing of exception.